### PR TITLE
Updating destination db name for lambda function in chapter 3.

### DIFF
--- a/Chapter03/CSVtoParquetLambda.py
+++ b/Chapter03/CSVtoParquetLambda.py
@@ -13,7 +13,7 @@ def lambda_handler(event, context):
     # then the following lines will set db to sakila and table_name to 'film'
     key_list = key.split("/")
     print(f'key_list: {key_list}')
-    db_name = key_list[len(key_list)-3]
+    db_name = 'cleanzonedb'
     table_name = key_list[len(key_list)-2]
     
     print(f'Bucket: {bucket}')


### PR DESCRIPTION
Right now, the Chapter 4 exercises don't work due to the wrong db name in the clean zone s3 bucket.  The existing code copies the database name from the landing zone s3 bucket, which is 'testdb'.  It needs to be 'cleanzonedb' in order to make the Chapter 4 exercises work.